### PR TITLE
[fix] LOAD segment with RWX permissions

### DIFF
--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -1,18 +1,30 @@
 ENTRY(kmain)
 
+PHDRS {
+    text PT_LOAD FLAGS(5);    /* Read + Execute */
+    rodata PT_LOAD FLAGS(4);  /* Read only */
+    data PT_LOAD FLAGS(6);    /* Read + Write */
+}
+
 SECTIONS {
     . = 1M;
 
     .text : {
         *(.text*)
-    }
+    } :text
 
-    .rodata : { *(.rodata*) }
-    .data : { *(.data*) }
+    .rodata : {
+        *(.rodata*)
+    } :rodata
+
+    .data : {
+        *(.data*)
+    } :data
+
     .bss : {
         *(.bss*)
         *(COMMON)
-    }
+    } :data
 
     .stack (NOLOAD) : {
         . = ALIGN(4);


### PR DESCRIPTION
Fixes following warning:

```
i386-elf-ld: warning: build/kernel.elf has a LOAD segment with RWX permissions
```

Known issue: missing function definition for `disk_read_sector` in `/kernel/fat12.c`

resolves #82 