### PR TITLE
Fix incorrect code segment handling

### DIFF
--- a/bootloader/stage2.asm
+++ b/bootloader/stage2.asm
@@ -84,10 +84,6 @@ pm_entry:
     mov gs, ax
     mov ss, ax
 
-    ; Code segment
-    mov ax, 0x08
-    mov cs, ax
-
     ; Stack
     mov esp, 0x90000
 


### PR DESCRIPTION
Fixes the issue mentioned in #133, by removing the unnecessary (and incorrect) `mov cs, ax` (and the thus unnecessary `mov` preceding it)

Closes #133 